### PR TITLE
Add --profile flag to specify profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ $ GO111MODULE=on go get github.com/adhocteam/ssm
 ```
 
 ### Usage
+
+
 #### List params
 All parameters:
 ```
@@ -26,6 +28,11 @@ ssm ls /my-app
 ssm get /myapp/staging/key
 ```
 
+You can use the value of a parameter in a bash script like
+```
+PGPASSWORD=$(ssm get /myapp/prod/pgpass)
+```
+
 #### Set param key value
 ```
 ssm set /myapp/staging/version 27
@@ -35,3 +42,8 @@ ssm set /myapp/staging/version 27
 ```
 ssm rm /myapp/staging/version
 ```
+
+### Specifying the AWS Profile
+The app will either rely on the `AWS_PROFILE` environment variable,
+or you can set one with the `-p` and `--profile` flag. For each example above,
+ add that flag, i.e. `ssm -p myprofile ls myapp` to override the `AWS_PROFILE`.

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	app.Commands = []cli.Command{
 		{
 			Name:  "ls",
-			Usage: "list param names. ex: ssm ls myapp, ssm ls",
+			Usage: "list param names. ex: ssm ls myapp, ssm ls, ssm ls --secrets myapp",
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:        "secrets",


### PR DESCRIPTION
Someone requested adding a flag to manually specify the AWS profile. This adds the global flag pair `--profile, -p` to do that. It can be invoked like:

```
ssm -p myprofile ls --secrets /myapp/production
```

It's done by setting the environment variable `AWS_PROFILE` via `os.Setnv`, which is one of the ways Amazon recommends doing that in https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html