### PR TITLE
Use fewer goroutines to fetch secrets, some cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.18
     steps:
       - checkout
       - run: GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.18
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - run: GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck

--- a/main.go
+++ b/main.go
@@ -14,22 +14,20 @@ import (
 	"github.com/urfave/cli"
 )
 
-var (
-	// show secrets in plaintext
-	secrets = false
-	// aws profile
-	profile = ""
-	// don't print newline on ssm get
-	noNewLine = false
-	// don't print timestamps of params
-	hideTS = false
-	// remove leading environment; /prod/version -> version
-	stripPrefix = false
-	// print tuple of parameter histories
-	showHistory = false
-)
-
 func main() {
+
+	// show secrets in plaintext
+	secrets := false
+	// aws profile
+	profile := ""
+	// don't print newline on ssm get
+	noNewLine := false
+	// don't print timestamps of params
+	hideTS := false
+	// remove leading environment; /prod/version -> version
+	stripPrefix := false
+	// print tuple of parameter histories
+	showHistory := false
 
 	app := cli.NewApp()
 	app.Version = "1.4.2"
@@ -273,7 +271,7 @@ func list(s string, showValue, ts, stripPrefix, showHistory bool, service *ssm.S
 	}
 
 	// set n workers based on how many requests may happen
-	nworkers := 5
+	nworkers := 2
 
 	if showHistory {
 		nworkers = 1

--- a/release.sh
+++ b/release.sh
@@ -6,3 +6,5 @@ GOOS=darwin GOARCH=amd64 go build -o release/ssm-darwin-amd64
 sha256sum release/ssm-darwin-amd64 >release/ssm-darwin-amd64.sha
 GOOS=linux GOARCH=amd64 go build -o release/ssm-linux-amd64
 sha256sum release/ssm-darwin-amd64 >release/ssm-linux-amd64.sha
+GOOS=darwin GOARCH=arm64 go build -o release/ssm-darwin-arm64
+sha256sum release/ssm-darwin-amd64 >release/ssm-darwin-arm64.sha


### PR DESCRIPTION
This lowers the number of goroutines fetching secrets from SSM to two at a time. Although unscientific, recently running 5 has been getting rate-limited by AWS.