### PR TITLE
putting key name when error retrieving

### DIFF
--- a/main.go
+++ b/main.go
@@ -381,7 +381,7 @@ func get(key string, service *ssm.SSM) (string, error) {
 		WithDecryption: &withDecryption,
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error retrieving key %s: %w", key, err)
 	}
 
 	value := *param.Parameter.Value


### PR DESCRIPTION
When there is an error retrieving key, it just says "ParameterNotFound" and doesn't list what the key is.  When this tool is used in jobs that retrieve multiple parameters, it is hard to know which one it had the error with.  Adding the key name in the return error. 