### PR TITLE
Add an option to set value as non-secure string.  Add a Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 build: *.go
 	GOOS=windows GOARCH=amd64 go build -o windows/ssm.exe -tags forceposixssm
-	GOOS=darwin GOARCH=amd64 go build -o macos/ssm -tags forceposixssm
+	GOOS=darwin GOARCH=amd64 go build -o macos-amd64/ssm -tags forceposixssm
+	GOOS=darwin GOARCH=arm64 go build -o macos-arm64/ssm -tags forceposixssm
 	GOOS=linux GOARCH=amd64 go build -o linux-x64/ssm -tags forceposixssm
 	GOOS=linux GOARCH=arm64 go build -o linux-arm64/ssm -tags forceposixssm
 	GOOS=linux GOARCH=arm go build -o linux-arm/ssm -tags forceposixssm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build: *.go
+	GOOS=windows GOARCH=amd64 go build -o windows/ssm.exe -tags forceposixssm
+	GOOS=darwin GOARCH=amd64 go build -o macos/ssm -tags forceposixssm
+	GOOS=linux GOARCH=amd64 go build -o linux-x64/ssm -tags forceposixssm
+	GOOS=linux GOARCH=arm64 go build -o linux-arm64/ssm -tags forceposixssm
+	GOOS=linux GOARCH=arm go build -o linux-arm/ssm -tags forceposixssm
+	GOOS=freebsd GOARCH=amd64 go build -o freebsd-x64/ssm -tags forceposixssm


### PR DESCRIPTION
This PR adds a flag to specify a non-secure string as a value (instead of the default securestring).  There are some reasons why we want to input a non-secure string and having the option is helpful.

This also adds a simple Makefile to build for many common platforms.  Simply run "make build".

Thank you for considering this PR.  Great work on this utility - it is very helpful.